### PR TITLE
デバッグ用のgemを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'pry-rails'
   gem 'pry-byebug'
+
 end
 
 group :development do


### PR DESCRIPTION
# 概要 
- railsでも`biding.pry`を使えるようにするためにdebug用のgemを追加